### PR TITLE
[Proposal] App Catalog Cleanup Reusable Workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -54,13 +54,13 @@ jobs:
         run: |
           if [[ ! -z "${{ inputs.keep-since }}" ]]
           then
-            echo "::set-output name=condition::--keep-since '${{ inputs.keep-since }}'"
+            echo '::set-output name=condition::--keep-since "${{ inputs.keep-since }}"'
           elif [[ ! -z "${{ inputs.delete-before }}" ]]
           then
-            echo "::set-output name=condition::--delete-before '${{ inputs.delete-before }}'"
-          elif [[ ! -z "${{ inputs.limit-number }}" ]]
+            echo '::set-output name=condition::--delete-before "${{ inputs.delete-before }}"'
+          elif (( ${{ inputs.limit-number }} > 0 ))
           then
-            echo "::set-output name=condition::--limit-number ${{ inputs.limit-number }}"
+            echo '::set-output name=condition::--limit-number ${{ inputs.limit-number }}'
           else
             echo "::set-output name=condition::"
           fi

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   cleanup:
-    name: Run the ACCT tool
+    name: Run the ACC tool
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -47,6 +47,16 @@ jobs:
             echo '::set-output name=dry-run::--dry-run'
           else
             echo '::set-output name=dry-run::'
+          fi
+
+      - name: Check for debug
+        id: debug
+        run: |
+          if [ ${{ inputs.debug }} = true ]
+          then
+            echo '::set-output name=debug::debug'
+          else
+            echo '::set-output name=debug::'
           fi
 
       - name: Conclude condition
@@ -68,4 +78,22 @@ jobs:
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
         with:
-          args: -a "${{ inputs.app-regexp }}" ${{ steps.condition.outputs.condition }} ${{ steps.dry-run.outputs.dry-run }} .
+          args: -a "${{ inputs.app-regexp }}" ${{ steps.condition.outputs.condition }} ${{ steps.dry-run.outputs.dry-run }} ${{ steps.dry-run.outputs.dry-run }} .
+
+      - name: Create Pull Request
+        if: ${{ inputs.dry-run }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Periodic App Catalog Cleanup
+          commit-message: Periodic App Catalog Cleanup
+          branch: cleanup/acct-run
+          draft: true
+          body: |
+            Periodic cleanup.
+
+            - Application Regexp: ${{ inputs.app-regexp }}
+            - Cleanup Condition: ${{ steps.condition.outputs.condition }}
+            - Created By: [ACCT Github Workflow][1]
+
+            [1]: https://raw.githubusercontent.com/giantswarm/app-catalog-cleanup-tool/feature/cleanup-workflow/.github/workflows/cleanup.yaml

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -45,6 +45,7 @@ jobs:
       - name: Check for dry-run
         id: dry-run
         run: |
+          echo ${{ secrets.token }}
           if [ ${{ inputs.dry-run }} = true ]
           then
             echo '::set-output name=dry-run::--dry-run'

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
+        with:
+          args: .
         env:
           ACCT_APP_REGEXP: ${{ inputs.app-regexp }}
           ACCT_KEEP_SINCE: ${{ inputs.keep-since }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -52,10 +52,18 @@ jobs:
       - name: Conclude condition
         id: condition
         run: |
-          [ -z "${{ inputs.keep-since }}" ] || echo "::set-output name=condition::--keep-since=${{ inputs.keep-since }}"; exit 0
-          [ -z "${{ inputs.delete-before }}" ] || echo "::set-output name=condition::--delete-before=${{ inputs.delete-before }}"; exit 0
-          [ -z "${{ inputs.limit-number }}" ] || echo "::set-output name=condition::--limit-number=${{ inputs.limit-number }}"; exit 0
-          echo "::set-output name=condition::"
+          if [[ ! -z "${{ inputs.keep-since }}" ]]
+          then
+            echo "::set-output name=condition::--keep-since=${{ inputs.keep-since }}"
+          elif [[ ! -z "${{ inputs.delete-before }}" ]]
+          then
+            echo "::set-output name=condition::--delete-before=${{ inputs.delete-before }}"
+          elif [[ ! -z "${{ inputs.limit-number }}" ]]
+          then
+            echo "::set-output name=condition::--limit-number=${{ inputs.limit-number }}"
+          else
+            echo "::set-output name=condition::"
+          fi
 
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Ignore index.yaml.back file
+        run: echo "index.yaml.back" >> .git/info/exclude
+
       - name: Check for dry-run
         id: dry-run
         run: |
@@ -92,8 +95,8 @@ jobs:
           body: |
             Periodic cleanup.
 
-            - Application Regexp: ${{ inputs.app-regexp }}
-            - Cleanup Condition: ${{ steps.condition.outputs.condition }}
+            - Application Regexp: `${{ inputs.app-regexp }}`
+            - Cleanup Condition: `${{ steps.condition.outputs.condition }}`
             - Created By: [ACCT Github Workflow][1]
 
             [1]: https://raw.githubusercontent.com/giantswarm/app-catalog-cleanup-tool/feature/cleanup-workflow/.github/workflows/cleanup.yaml

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,40 @@
+name: App Catalog Cleanup
+
+on:
+  workflow_call:
+    inputs:
+      app-regexp:
+        description: "Regexp of app names the cleanup will apply to"
+        default: ".*"
+        required: false
+        type: string
+      keep-since:
+        description: "Entries older than this timestamp will be removed"
+        default: "2020-01-01"
+        required: false
+        type: string
+      debug:
+        description: "Enable debug mode"
+        default: true
+        required: false
+        type: boolean
+      dry-run:
+        description: "Enable dry-run mode"
+        default: true
+        required: false
+        type: boolean
+
+jobs:
+  cleanup:
+    name: Run the ACC tool
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Execute ACC tool
+        uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
+        env:
+          ACCT_APP_REGEXP: ${{ inputs.app-regexp }}
+          ACCT_KEEP_SINCE: ${{ inputs.keep-since }}
+          ACCT_DEBUG: ${{ inputs.debug }}
+          ACCT_DRY_RUN: ${{ inputs.dry-run }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -30,9 +30,6 @@ on:
         default: true
         required: false
         type: boolean
-    secrets:
-      token:
-        required: true
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -84,7 +84,7 @@ jobs:
           args: -a "${{ inputs.app-regexp }}" ${{ steps.condition.outputs.condition }} ${{ steps.dry-run.outputs.dry-run }} ${{ steps.dry-run.outputs.dry-run }} .
 
       - name: Create Pull Request
-        if: ${{ inputs.dry-run }}
+        if: ${{ ! inputs.dry-run }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ github.token }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -19,7 +19,7 @@ on:
       limit-number:
         description: "Most recent versions to keep in the catalog"
         required: false
-        type: number
+        type: string
       debug:
         description: "Enable debug mode"
         default: true
@@ -42,11 +42,11 @@ jobs:
       - name: Check for dry-run
         id: dry-run
         run: |
-          if [ "${{ inputs.dry-run }}" = true ]
+          if [ ${{ inputs.dry-run }} = true ]
           then
-            echo "::set-output name=dry-run::--dry-run"
+            echo '::set-output name=dry-run::--dry-run'
           else
-            echo "::set-output name=dry-run::"
+            echo '::set-output name=dry-run::'
           fi
 
       - name: Conclude condition
@@ -58,11 +58,11 @@ jobs:
           elif [[ ! -z "${{ inputs.delete-before }}" ]]
           then
             echo '::set-output name=condition::--delete-before "${{ inputs.delete-before }}"'
-          elif (( ${{ inputs.limit-number }} > 0 ))
+          elif [[ ! -z "${{ inputs.limit-number }}" ]]
           then
             echo '::set-output name=condition::--limit-number ${{ inputs.limit-number }}'
           else
-            echo "::set-output name=condition::"
+            echo '::set-output name=condition::'
           fi
 
       - name: Execute ACC tool

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -90,7 +90,8 @@ jobs:
           token: ${{ github.token }}
           title: Periodic App Catalog Cleanup
           commit-message: Periodic App Catalog Cleanup
-          branch: cleanup/acct-run
+          branch: cleanup/acct-run-${{ github.run_id }}
+          delete-branch: true
           draft: true
           body: |
             Periodic cleanup.

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -30,6 +30,9 @@ on:
         default: true
         required: false
         type: boolean
+    secrets:
+      token:
+        required: true
 
 jobs:
   cleanup:
@@ -84,7 +87,7 @@ jobs:
         if: ${{ inputs.dry-run }}
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.token }}
           title: Periodic App Catalog Cleanup
           commit-message: Periodic App Catalog Cleanup
           branch: cleanup/acct-run

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -57,7 +57,7 @@ jobs:
             echo "::set-output name=condition::--keep-since=${{ inputs.keep-since }}"
           elif [[ ! -z "${{ inputs.delete-before }}" ]]
           then
-            echo "::set-output name=condition::--delete-before=${{ inputs.delete-before }}"
+            echo "::set-output name=condition::--delete-before='${{ inputs.delete-before }}'"
           elif [[ ! -z "${{ inputs.limit-number }}" ]]
           then
             echo "::set-output name=condition::--limit-number=${{ inputs.limit-number }}"

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -45,7 +45,6 @@ jobs:
       - name: Check for dry-run
         id: dry-run
         run: |
-          echo ${{ secrets.token }}
           if [ ${{ inputs.dry-run }} = true ]
           then
             echo '::set-output name=dry-run::--dry-run'
@@ -88,7 +87,7 @@ jobs:
         if: ${{ inputs.dry-run }}
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.token }}
+          token: ${{ github.token }}
           title: Periodic App Catalog Cleanup
           commit-message: Periodic App Catalog Cleanup
           branch: cleanup/acct-run

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -9,10 +9,17 @@ on:
         required: false
         type: string
       keep-since:
-        description: "Entries older than this timestamp will be removed"
-        default: "2020-01-01"
+        description: "A full date-time. Catalog entries older than this timestamp will be removed"
         required: false
         type: string
+      delete-before:
+        description: "A time delta (like '3 days' or '4 weeks') to keep catalog entries. Catalog entries older will be removed"
+        required: false
+        type: string
+      limit-number:
+        description: "Most recent versions to keep in the catalog"
+        required: false
+        type: number
       debug:
         description: "Enable debug mode"
         default: true
@@ -26,7 +33,7 @@ on:
 
 jobs:
   cleanup:
-    name: Run the ACC tool
+    name: Run the ACCT tool
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -35,7 +42,6 @@ jobs:
       - name: Check for dry-run
         id: dry-run
         run: |
-          echo ${{ inputs.dry-run }}
           if [ "${{ inputs.dry-run }}" = true ]
           then
             echo "::set-output name=dry-run::--dry-run"
@@ -43,10 +49,15 @@ jobs:
             echo "::set-output name=dry-run::"
           fi
 
+      - name: Conclude condition
+        id: condition
+        run: |
+          [ -z "${{ inputs.keep-since }}" ] || echo "::set-output name=condition::--keep-since=${{ inputs.keep-since }}"; exit 0
+          [ -z "${{ inputs.delete-before }}" ] || echo "::set-output name=condition::--delete-before=${{ inputs.delete-before }}"; exit 0
+          [ -z "${{ inputs.limit-number }}" ] || echo "::set-output name=condition::--limit-number=${{ inputs.limit-number }}"; exit 0
+          echo "::set-output name=condition::"
+
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
         with:
-          args: -a ${{ inputs.app-regexp }} -s ${{ inputs.keep-since }} ${{ steps.dry-run.outputs.dry-run }} .
-        env:
-          ACCT_APP_REGEXP: ${{ inputs.app-regexp }}
-          ACCT_KEEP_SINCE: ${{ inputs.keep-since }}
+          args: -a ${{ inputs.app-regexp }} ${{ steps.condition.outputs.condition }} ${{ steps.dry-run.outputs.dry-run }} .

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
         with:
-          args: . -a ${{ inputs.app-regexp }} -s ACCT_KEEP_SINCE: ${{ inputs.keep-since }} ${{ steps.dry-run.outputs.dry-run }}
+          args: -a ${{ inputs.app-regexp }} -s ${{ inputs.keep-since }} ${{ steps.dry-run.outputs.dry-run }} .
         env:
           ACCT_APP_REGEXP: ${{ inputs.app-regexp }}
           ACCT_KEEP_SINCE: ${{ inputs.keep-since }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -31,12 +31,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Check for dry-run
+        id: dry-run
+        run: |
+          echo ${{ inputs.dry-run }}
+          if [ "${{ inputs.dry-run }}" = true ]
+          then
+            echo "::set-output name=dry-run::--dry-run"
+          else
+            echo "::set-output name=dry-run::"
+          fi
+
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
         with:
-          args: .
+          args: . -a ${{ inputs.app-regexp }} -s ACCT_KEEP_SINCE: ${{ inputs.keep-since }} ${{ steps.dry-run.outputs.dry-run }}
         env:
           ACCT_APP_REGEXP: ${{ inputs.app-regexp }}
           ACCT_KEEP_SINCE: ${{ inputs.keep-since }}
-          ACCT_DEBUG: ${{ inputs.debug }}
-          ACCT_DRY_RUN: ${{ inputs.dry-run }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -54,13 +54,13 @@ jobs:
         run: |
           if [[ ! -z "${{ inputs.keep-since }}" ]]
           then
-            echo "::set-output name=condition::--keep-since=${{ inputs.keep-since }}"
+            echo "::set-output name=condition::--keep-since '${{ inputs.keep-since }}'"
           elif [[ ! -z "${{ inputs.delete-before }}" ]]
           then
-            echo "::set-output name=condition::--delete-before='${{ inputs.delete-before }}'"
+            echo "::set-output name=condition::--delete-before '${{ inputs.delete-before }}'"
           elif [[ ! -z "${{ inputs.limit-number }}" ]]
           then
-            echo "::set-output name=condition::--limit-number=${{ inputs.limit-number }}"
+            echo "::set-output name=condition::--limit-number ${{ inputs.limit-number }}"
           else
             echo "::set-output name=condition::"
           fi
@@ -68,4 +68,4 @@ jobs:
       - name: Execute ACC tool
         uses: docker://quay.io/giantswarm/app-catalog-cleanup-tool:latest
         with:
-          args: -a ${{ inputs.app-regexp }} ${{ steps.condition.outputs.condition }} ${{ steps.dry-run.outputs.dry-run }} .
+          args: -a "${{ inputs.app-regexp }}" ${{ steps.condition.outputs.condition }} ${{ steps.dry-run.outputs.dry-run }} .


### PR DESCRIPTION
### TL;DR

This PR introduces a custom GHA workflow that stands the interface to run the ACCT against the catalog repositories that references it. It follows the [Reusable Workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) guide, which although being in beta, seems to work quite fine. A small issue described below has been spotted, but it also seems quite easy to overcome.

### Spotted issues

Passing the GH token between the caller and called workflows is the only problem spotted so far. The reusable workflow may define `secrets` the other workflows can pass by upon calling it, but this mechanism does not seem to work with the GH tokens. Though, they can still be accessed by the reusable workflow using the `github` context, see `Create Pull Request` step.

### Why reusable workflow?

It seems the best fit the use case. Other natural choice would be a dedicated GH Action, but this repository feels to be rather dedicated to the ACCT application and its releases, so turning it into the GHA repository doesn't feel right, neither creating an extra repository for that purpose. Workflow is in addition more flexible, action corresponds to a single step, while we can craft any number of them in a workflow.

### Referencing workflow

Catalog repos can reference this workflow in their own workflows, see the [Control Plane Test Catalog example](https://raw.githubusercontent.com/giantswarm/control-plane-test-catalog/feature/cleanup-workflow/.github/workflows/cleanup.yaml), or the snippet below.

```yaml
name: Control Plane Test Catalog Cleanup

on:
  schedule:
    - cron: "0 0 1 * *"

jobs:
  cleanup:
    uses: giantswarm/app-catalog-cleanup-tool/.github/workflows/cleanup.yaml@feature/cleanup-workflow
    with:
      delete-before: "1 month"
      dry-run: false
```

### Commiting changes

Creating a PR seems like an obvious way of commiting cleanup. We could easily revert it in case of any issues or cleaning up too much. In result, the workflow, after running the ACCT opens a PR with changes.

### Yet to be done

**Merging**: how would we like to merge the cleanup PR. It may depend on the catalog type, like for example we could use auto-merge on `-test` catalogs and approvals on the production catalogs.

**PR Notifications**: for the repositories without auto-merge, what would be the notification channel to inform owners of the catalog repository about the PR ready for merge? Pinging on the Slack's channel maybe?

**General notification**: do we want somehow track the entries we remove, except the GHA stdout and PR diff itself? Like for example in form of metrics or logs stored somewhere?
