### PR TITLE
Update `team-reviewers` input

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -91,7 +91,7 @@ jobs:
           title: Periodic App Catalog Cleanup
           commit-message: Periodic App Catalog Cleanup
           branch: cleanup/acct-run-${{ github.run_id }}
-          team-reviewers: giantswarm/team-honeybadger
+          team-reviewers: team-honeybadger
           delete-branch: true
           draft: true
           body: |


### PR DESCRIPTION
I am bit confused by the `team-reviewers` input.

The PRs opened by this workflow do not have the reviewers set. It is either due to the lack of permissions, however I haven't seen any explicit errors in the corresponding actions, e.g. [here](https://github.com/giantswarm/control-plane-test-catalog/runs/3859823851?check_suite_focus=true#step:9:12005), or due to the wrong team name. I would like to test the PR action without the `giantswarm` prefix for the team, especially, [the GH API](https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request) mentions the slug for the team, and the slug does not contains the prefix. 