### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,64 +1,61 @@
 version: 2.1
 
 orbs:
-    architect: giantswarm/architect@4.33.0
-    codecov: codecov/codecov@3.2.0
+  architect: giantswarm/architect@4.35.5
+  codecov: codecov/codecov@3.2.0
 
 workflows:
-    test:
-        jobs:
-            -   run-tests:
-                    name: run-tests
-                    filters:
+  test:
+    jobs:
+      - run-tests:
+          name: run-tests
+          filters:
                         # Needed to trigger job also on git tag.
-                        tags:
-                            only: /^v.*/
+            tags:
+              only: /^v.*/
 
-            -   architect/push-to-docker:
-                    name: push-to-quay
-                    requires:
-                        - run-tests
-                    context: architect
-                    image: "quay.io/giantswarm/app-catalog-cleanup-tool"
-                    username_envar: "QUAY_USERNAME"
-                    password_envar: "QUAY_PASSWORD"
-                    filters:
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
+          requires:
+            - run-tests
+          filters:
                         # Needed to trigger job also on git tag.
-                        tags:
-                            only: /^v.*/
+            tags:
+              only: /^v.*/
 
-            -   publish-github-release:
-                    name: publish-github-release
-                    requires:
-                        - push-to-quay
-                    filters:
-                        branches:
-                            ignore: /.*/
-                        tags:
-                            only: /^v.*/
+      - publish-github-release:
+          name: publish-github-release
+          requires:
+            - push-to-registries
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
 
 jobs:
-    run-tests:
-        machine:
-            image: ubuntu-2004:202010-01
-        steps:
-            - checkout
+  run-tests:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - checkout
 
-            -   run:
-                    name: Execute tests
-                    command: |
-                        make docker-test-ci
+      - run:
+          name: Execute tests
+          command: |
+            make docker-test-ci
 
-            -   codecov/upload:
-                    file: .coverage/coverage.xml
+      - codecov/upload:
+          file: .coverage/coverage.xml
 
-    publish-github-release:
-        docker:
-            -   image: cibuilds/github:0.10
-        steps:
-            - checkout
-            -   run:
-                    name: "Publish Release on GitHub"
-                    command: |
-                        ghr -t ${ARCHITECT_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./dacct.sh
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - checkout
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${ARCHITECT_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./dacct.sh

--- a/testrunner.Dockerfile
+++ b/testrunner.Dockerfile
@@ -20,7 +20,7 @@ COPY README.md .
 COPY Pipfile .
 COPY Pipfile.lock .
 COPY tests/ tests/
-COPY .git/ ./.git/
+RUN git init && git config --global --add safe.directory /acct
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --clear --dev
 RUN pipenv run pre-commit install-hooks
 ENTRYPOINT ["./run-tests-in-docker.sh"]


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- Double-check the job dependecies (`requires`).
- Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- Update the changelog if you think this deserves a mention.
- Approve and merge this PR once it's ready. No need to wait for the author in this case.
- Get this done until 1st of December, so that we can move on with follow-up steps.